### PR TITLE
Fix typo on finish course button

### DIFF
--- a/src/templates/messages.ts
+++ b/src/templates/messages.ts
@@ -30,7 +30,7 @@ const messages: Record<string, LanguageSwitcher> = {
   },
   finishCourse: {
     pt: 'Finalizar Curso',
-    en: 'Finish Cours',
+    en: 'Finish Course',
   },
   anyQuestion: {
     pt: 'Está com duvidas?',


### PR DESCRIPTION
#### What is the purpose of this pull request?

The "finish course" button is missing the "e" letter.

<img src="https://user-images.githubusercontent.com/17601387/104533033-5286a580-55f0-11eb-8c9f-fc0ee5ef7380.png"  width="300"/>

[Take a look here](https://developers.vtex.com/learning/docs/course-store-block-step08react-apollo-lang-en#finish-link)


#### What problem is this solving?

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
