### PR TITLE
Adding pre-setup for Master Data in Service Course

### DIFF
--- a/courses/service-course/steps/06_clients-masterdata/en.md
+++ b/courses/service-course/steps/06_clients-masterdata/en.md
@@ -20,6 +20,61 @@ In this step, it will be used to fetch data regarding the top-N most viewed prod
 
 > **NOTE:** It is important to highlight that the Master Data client will be available as long as the correct version of `@vtex/api` is installed in the node folder. It can be used by accessing `ctx.clients.masterdata`.
 
+## Before starting, if you are **not using** the `appliancetheme` account
+
+Before following our activity for this step, you will need to set up your **Master Data** to be able to use it.
+
+So, you'll have to create an entity to save your product list. To do so, using our [**Master Data API**](https://developers.vtex.com/vtex-developer-docs/reference/master-data-api-v2-overview), you'll save a new schema. 
+
+1. Using [Postman](https://www.postman.com/downloads/) or any other API client you prefer, send a `PUT` request to this route: `https://{{your-account-name}}.vtexcommercestable.com.br/api/dataentities/course_backend_product_list/schemas/{{your-schema-name}}` with the following headers and body:
+
+  > Note that you need to fill in some information on the route, such as `your-account-name` and `your-schema-name`. That last one can be anything, but we strongly recommend it to be something like `v0`. 
+
+  Headers: 
+  ```json  
+      Content-Type: application/json
+      VtexIdclientAutCookie: {your-token}
+  ```
+
+  Body: 
+  ```json  
+    {
+      "properties": {
+          "slug": {
+              "type": "string"
+          },
+          "count": {
+              "type": "number"
+          }
+      },
+      "v-indexed": [
+          "slug",
+          "count"
+      ],
+      "v-security": {
+          "allowGetAll": true,
+          "publicRead": [
+              "slug",
+              "count"
+          ],
+          "publicWrite": [
+              "slug",
+              "count"
+          ],
+          "publicFilter": [
+              "slug",
+              "count"
+          ]
+      }
+    }
+  ```
+
+  > To get your VTEX local token for the header, in your terminal run `vtex local token`. 
+
+By doing this, you are not only creating an entity but also creating a new schema to be used during this step. 
+
+Now you are good to go! 
+
 ## Using the Master Data client to store information
 
 1. First, we need to setup the policies in our app, to authorize it to use **Master Data**. To do so, complement the `manifest.json` file:

--- a/courses/service-course/steps/06_clients-masterdata/en.md
+++ b/courses/service-course/steps/06_clients-masterdata/en.md
@@ -71,6 +71,11 @@ So, you'll have to create an entity to save your product list. To do so, using o
 
   > To get your VTEX local token for the header, in your terminal run `vtex local token`. 
 
+  Your request should look like this if you are using *Postman*: 
+  ![headers](https://user-images.githubusercontent.com/43679629/108750696-182df380-7520-11eb-8cc3-178158ad8e94.png)
+  ![body](https://user-images.githubusercontent.com/43679629/108750714-1ebc6b00-7520-11eb-9f61-4a21160bceef.png)
+
+
 By doing this, you are not only creating an entity but also creating a new schema to be used during this step. 
 
 Now you are good to go! 

--- a/courses/service-course/steps/06_clients-masterdata/pt.md
+++ b/courses/service-course/steps/06_clients-masterdata/pt.md
@@ -27,7 +27,7 @@ Antes de começar a atividade desse passo, você precisa configurar o seu **Mast
 
 Então, você precisa criar uma entidade para salvar a sua lista de produtos. Para fazer isso, usando a nossa [**API do Master Data**](https://developers.vtex.com/vtex-developer-docs/reference/master-data-api-v2-overview), você  vai salvar um novo *schema*.
 
-1. Usando o [Postman](https://www.postman.com/downloads/) ou qualquer outro cliente para APIs que preferir, faça um request `PUT` para esta rota `https://{{nome-da-sua-conta}}.vtexcommercestable.com.br/api/dataentities/course_backend_product_list/schemas/{{nome-do-seu-schema}}` com os seguintes *headers* e *body*:
+1. Usando o [Postman](https://www.postman.com/downloads/) ou qualquer outro cliente para APIs que preferir, faça um *request* `PUT` para esta rota `https://{{nome-da-sua-conta}}.vtexcommercestable.com.br/api/dataentities/course_backend_product_list/schemas/{{nome-do-seu-schema}}` com os seguintes *headers* e *body*:
 
   > Note que você precisa preencher algumas informações na rota, como o `nome-da-sua-conta` e `nome-do-seu-schema`. Esse último pode ser qualuqer nome, mas recomendamos algo como `v0`. 
 
@@ -71,6 +71,11 @@ Então, você precisa criar uma entidade para salvar a sua lista de produtos. Pa
   ```
 
   > Para pegar um VTEX *local token* para o *header*, basta rodar no seu terminal `vtex local token`. 
+
+   Seu *request* deve ser algo parecido com as imagens abaixo se você estiver usando o *Postman*:
+   ![headers](https://user-images.githubusercontent.com/43679629/108750696-182df380-7520-11eb-8cc3-178158ad8e94.png)
+   ![body](https://user-images.githubusercontent.com/43679629/108750714-1ebc6b00-7520-11eb-9f61-4a21160bceef.png)
+
 
 Fazendo isso, você não só está criando a entidade mas também criando um novo *schema* que será usado nessa atividade.
 

--- a/courses/service-course/steps/06_clients-masterdata/pt.md
+++ b/courses/service-course/steps/06_clients-masterdata/pt.md
@@ -21,6 +21,60 @@ Neste passo, este cliente será utilizado para pegar informações dos N produto
 > Nota: É importante ressaltar que o cliente do Master Data estará disponível para ser utilizado desde que a versão correta do `@vtex/api` esteja instalada na pasta `node`. Ele poderá ser acessado através de `ctx.clients.masterdata`.
 
 Vamos começar?
+## Antes, se você **não está usando** a conta `appliancetheme`
+
+Antes de começar a atividade desse passo, você precisa configurar o seu **Master Data** para poder usar do jeito que a atividade propõe.
+
+Então, você precisa criar uma entidade para salvar a sua lista de produtos. Para fazer isso, usando a nossa [**API do Master Data**](https://developers.vtex.com/vtex-developer-docs/reference/master-data-api-v2-overview), você  vai salvar um novo *schema*.
+
+1. Usando o [Postman](https://www.postman.com/downloads/) ou qualquer outro cliente para APIs que preferir, faça um request `PUT` para esta rota `https://{{nome-da-sua-conta}}.vtexcommercestable.com.br/api/dataentities/course_backend_product_list/schemas/{{nome-do-seu-schema}}` com os seguintes *headers* e *body*:
+
+  > Note que você precisa preencher algumas informações na rota, como o `nome-da-sua-conta` e `nome-do-seu-schema`. Esse último pode ser qualuqer nome, mas recomendamos algo como `v0`. 
+
+  *Headers*: 
+  ```json  
+      Content-Type: application/json
+      VtexIdclientAutCookie: {seu-token}
+  ```
+
+  *Body*: 
+  ```json  
+    {
+      "properties": {
+          "slug": {
+              "type": "string"
+          },
+          "count": {
+              "type": "number"
+          }
+      },
+      "v-indexed": [
+          "slug",
+          "count"
+      ],
+      "v-security": {
+          "allowGetAll": true,
+          "publicRead": [
+              "slug",
+              "count"
+          ],
+          "publicWrite": [
+              "slug",
+              "count"
+          ],
+          "publicFilter": [
+              "slug",
+              "count"
+          ]
+      }
+    }
+  ```
+
+  > Para pegar um VTEX *local token* para o *header*, basta rodar no seu terminal `vtex local token`. 
+
+Fazendo isso, você não só está criando a entidade mas também criando um novo *schema* que será usado nessa atividade.
+
+Agora você está pronto para começar!
 
 ## Utilizando o cliente do Master Data para armazenar informação
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a pre-setup for Master Data in step 6 of Service Course.

#### What problem is this solving?

Many people are using their own account for taking these courses and these accounts doesn't have a schema for the entity that is used for this course. I added this setup before the activity, so everybody can be at the same point we expect them to be when starting the activity outside the `appliancetheme` account.

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
