### PR TITLE
Fix missing coma on one of the code snippets

### DIFF
--- a/courses/store-performance/steps/05_searching/pt.md
+++ b/courses/store-performance/steps/05_searching/pt.md
@@ -41,7 +41,7 @@ Uma das operações mais pesadas e pouco performáticas na navegação de uma lo
      "store.search": {
        "props": {
          "context": {
-           "skusFilter": "FIRST_AVAILABLE"
+           "skusFilter": "FIRST_AVAILABLE",
    +       "simulationBehavior": "skip"
          }
        },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a missing coma between properties of a given JSON object.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
When following the course flow, copying the given snippet of code will result in an syntax error due to the missing coma.
Minor issue as it's easy to detect but saves a tiny bit of time wasted.

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
