### PR TITLE
Fix broken links reported in docs feedback #1416

### DIFF
--- a/courses/store-block/steps/00_introduction/en.md
+++ b/courses/store-block/steps/00_introduction/en.md
@@ -22,4 +22,4 @@ If you are not familiar with any of those tools, we encourage you to take a look
 
 In order for you to start the course, you can use the template repository that we provide will all the initial files that you need to have so you can get started. You will find the repository in this [link](https://github.com/vtex-trainings/store-block-template).
 
-> If you do not quite understand how to use a template repository, you can check this [article](https://developers.vtex.com/page/how-to-use-a-template-repository).
+> If you do not quite understand how to use a template repository, you can check this [article](https://learn.vtex.com/page/how-to-use-a-template-repository).

--- a/courses/store-block/steps/00_introduction/pt.md
+++ b/courses/store-block/steps/00_introduction/pt.md
@@ -22,4 +22,4 @@ Se você não está familiarizado com alguma destas ferramentas, nós o encoraja
 
 Para começar o curso, você deve utilizar o repositório _template_ que disponibilizamos com todos os arquivos iniciais que você precisa ter para começar. Você encontrará este repositório neste [link](https://github.com/vtex-trainings/store-block-template).
 
-> Se você ainda tem dúvidas em como utilizar um repositório _template_, você pode checar este [artigo](https://developers.vtex.com/page/como-utilizar-um-reposit%C3%B3rio-template).
+> Se você ainda tem dúvidas em como utilizar um repositório _template_, você pode checar este [artigo](https://learn.vtex.com/page/como-utilizar-um-reposit%C3%B3rio-template).


### PR DESCRIPTION
#### What is the purpose of this pull request?

```
URL broken in the following sentence (bottom of page):

"If you do not quite understand how to use a template repository, you can check this article."
```

#### What problem is this solving?

See [Documentation Feedback #1416](https://vtex.slack.com/archives/CTW0F5JCQ/p1631208767035300) for more details.

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
