### PR TITLE
Fix diff block formatting

### DIFF
--- a/courses/basic-blocks/steps/02_richtext/en.md
+++ b/courses/basic-blocks/steps/02_richtext/en.md
@@ -113,21 +113,21 @@ To center align the text, we can add the `textPosition` prop and give it the `CE
 
 Define a [Rich Text](https://developers.vtex.com/docs/vtex-rich-text#rich-text) on your home page and create a **bold** "Hello, World!" that's **right-aligned**. Do so by adding a code block like this in the `store/blocks/home.jsonc` file:
 
-    ```diff
-    {
-      "store.home": {
-        "blocks": [
-    +      "rich-text"
-        ]
-      },
-    +  "rich-text": {
-    +    "props": {
-    +      "text": "**Hello, World!**",
-    +      "textPosition": "RIGHT"
-    +    }
-    +  }
-    }
-    ```
+```diff
+{
+  "store.home": {
+    "blocks": [
++      "rich-text"
+    ]
+  },
++  "rich-text": {
++    "props": {
++      "text": "**Hello, World!**",
++      "textPosition": "RIGHT"
++    }
++  }
+}
+```
 
 After running `vtex link`, your `rich-text` should look like this:
 

--- a/courses/basic-blocks/steps/02_richtext/pt.md
+++ b/courses/basic-blocks/steps/02_richtext/pt.md
@@ -113,21 +113,21 @@ Para centralizar o alinhamento do texto, podemos adicionar a prop `textPosition`
 
 Defina um [Rich Text](https://developers.vtex.com/docs/vtex-rich-text#rich-text) em sua página inicial e crie um **negrito** "Hello, World!" que está **alinhado à direita**. Faça isso trocando o código já presente no arquivo `store/blocks/home.jsonc` por este:
 
-    ```diff
-    {
-      "store.home": {
-        "blocks": [
-    +      "rich-text"
-        ]
-      },
-    +  "rich-text": {
-    +    "props": {
-    +      "text": "**Hello, World!**",
-    +      "textPosition": "RIGHT"
-    +    }
-    +  }
-    }
-    ```
+```diff
+{
+  "store.home": {
+    "blocks": [
++      "rich-text"
+    ]
+  },
++  "rich-text": {
++    "props": {
++      "text": "**Hello, World!**",
++      "textPosition": "RIGHT"
++    }
++  }
+}
+```
 
 Depois de executar o `vtex link`, seu `rich-text` deve ficar assim:
 


### PR DESCRIPTION
#### What problem is this solving?

Small formatting issue in [Getting started with Rich Text](https://learn.vtex.com/docs/course-basic-blocks-step02richtext-lang-en#activity), where the code block wasn't being formatted as a diff, but instead looked like this:

    ```diff
    {
      "store.home": {
        "blocks": [
    +      "rich-text"
        ]
      },
    +  "rich-text": {
    +    "props": {
    +      "text": "**Hello, World!**",
    +      "textPosition": "RIGHT"
    +    }
    +  }
    }
    ```

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
