### PR TITLE
fix basic blocks > search answer code to display as JSON (#215)

### DIFF
--- a/courses/basic-blocks/steps/06_search/en.md
+++ b/courses/basic-blocks/steps/06_search/en.md
@@ -75,22 +75,22 @@ Copy the code above in `search.jsonc` and define a `search-result-layout.desktop
 
 To do so, write a code similar to:
 
-    ```json
-    ...
-      },
-      "search-result-layout.desktop": {
-        "children": [
-          "breadcrumb.search",
-          "search-title.v2",
-          "total-products.v2",
-          "order-by.v2",
-          "search-fetch-previous",
-          "search-content",
-          "filter-navigator.v3",
-          "search-fetch-more"
-        ]
-      }
-    ...
-    ```
+```json
+...
+  },
+  "search-result-layout.desktop": {
+    "children": [
+      "breadcrumb.search",
+      "search-title.v2",
+      "total-products.v2",
+      "order-by.v2",
+      "search-fetch-previous",
+      "search-content",
+      "filter-navigator.v3",
+      "search-fetch-more"
+    ]
+  }
+...
+```
 
 Note: Remember to go through the Search Result [documentation](https://developers.vtex.com/docs/vtex-search-result) if you have any questions during the activity.

--- a/courses/basic-blocks/steps/06_search/pt.md
+++ b/courses/basic-blocks/steps/06_search/pt.md
@@ -75,22 +75,22 @@ Copie os códigos acima no arquivo `search.jsonc` e defina a `search-result-layo
 
 Para isso, escreva um código similar a este:
 
-    ```json
-    ...
-      },
-      "search-result-layout.desktop": {
-        "children": [
-          "breadcrumb.search",
-          "search-title.v2",
-          "total-products.v2",
-          "order-by.v2",
-          "search-fetch-previous",
-          "search-content",
-          "filter-navigator.v3",
-          "search-fetch-more"
-        ]
-      }
-    ...
-    ```
+```json
+...
+  },
+  "search-result-layout.desktop": {
+    "children": [
+      "breadcrumb.search",
+      "search-title.v2",
+      "total-products.v2",
+      "order-by.v2",
+      "search-fetch-previous",
+      "search-content",
+      "filter-navigator.v3",
+      "search-fetch-more"
+    ]
+  }
+...
+```
 
 Note: Lembre-se de olhar a [documentação](https://developers.vtex.com/docs/vtex-search-result) caso tenha dúvidas ao longo da atividade.


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the markdown indentation to show JSON code properly

#### What problem is this solving?

Issue #215 

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
