### PR TITLE
Fix information divergence between class content and answer sheet reported on issue #217

### DIFF
--- a/courses/layout-blocks/steps/08_stack-layout/answersheet/home.jsonc
+++ b/courses/layout-blocks/steps/08_stack-layout/answersheet/home.jsonc
@@ -7,7 +7,7 @@
   },
   "image#cta": {
     "props": {
-      "blockClass": "cta",
+      "blockClass": "cover",
       "width": "100%",
       "height": 400,
       "src": "https://appliancetheme.vtexassets.com/assets/app/src/appliancecat___1b7592b49667c6a89203a0997e06bc87.jpg"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Changing the "image#cta" "blockClass" prop from "cta" to "cover" in the answer sheet (vtex-courses/courses/layout-blocks/steps/08_stack-layout/answersheet/home.jsonc line 10, position 24.)

#### What problem is this solving?

There was a discrepancy between the lesson content and the answer sheet content, as noted in issue #217.
In class the "blockClass" prop of "image#cta" is filled with "cover" and in the answer sheet it is filled with "cta". Filling with "cta" prevents the rendering of the background image as shown in the class, this causes confusion in students' minds and leads to error, it must be "cover".

#### Types of changes

- [ ] Content fix
- [X] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
