### PR TITLE
Updating explanation on how to install vtex.mocked-analytics

### DIFF
--- a/courses/service-course/steps/04_clients-analytics/en.md
+++ b/courses/service-course/steps/04_clients-analytics/en.md
@@ -61,7 +61,7 @@ In this step, we will implement the Analytics client. So,
 
    > The method that you've just created will get the necessary data for this application: an array of objects that have two fields: `slug`, a string that represents the product ID and `liveUsers`, a number that is the quantity of users visualizing this product - which are the fields in the interface.
 
-4. The `_v/live-products` API endpoint we call above needs the app `mocked-analytics` to run, or your `getLiveUsers` method will not see anything there. **In case of not running this application on `appliancetheme` account**, you will have to install the `mocked-analytics` app on your workspace. To do that, you can run `vtex install vtex.mocked-analytics`.
+4. The `_v/live-products` API endpoint we call above needs the app `mocked-analytics` to run, or your `getLiveUsers` method will not see anything there. To check if the application is already installed, run the command `vtex list`. If not, use the following command: `vtex install vtex.mocked-analytics`.
 
 5. With your analytics client already implemented, it's necessary to declare it as one of the clients in the `Clients` class, so it will be accessible using the `Context` that we've talked about at the beginning of this step.
 

--- a/courses/service-course/steps/04_clients-analytics/pt.md
+++ b/courses/service-course/steps/04_clients-analytics/pt.md
@@ -60,7 +60,7 @@ Neste passo, vamos implementar o cliente de _Analytics_.
 
    > O método que você acabou de criar irá pegar os dados necessários para esta aplicação: um _array_ de objetos que contêm dois campos: `slug`, uma _string_ que representa o ID do produto e `liveUsers`, um número que é a quantidade de usuários visualizando o produto - que são os campos que estão na interface.
 
-4. O _endpoint_ `_v/live-products` que chamamos precisa da _app_ `mocked-analytics` para funcionar, ou seu método `getLiveUsers` não verá nenhum dado. **No caso de não estar rodando essa aplicação na conta `appliancetheme`**, você precisará instalar a aplicação `mocked-analytics` no seu _workspace_. Para fazer isso, você pode rodar o seguinte comando: `vtex install vtex.mocked-analytics`.
+4. O _endpoint_ `_v/live-products` que chamamos precisa da _app_ `mocked-analytics` para funcionar, ou seu método `getLiveUsers` não verá nenhum dado. Para checar se a aplicação já está instalada, rode o comando `vtex list`. Caso não esteja, utilize o seguinte comando: `vtex install vtex.mocked-analytics`.
 
 5. Com o seu cliente de _analytics_ já implementado, é necessário declará-lo como um dos clientes na classe `Clients`, de forma que ele ficará disponível e acessível através do uso de `Context`, do qual falamos anteriormente.
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This pull request aims to add more details on the installation of `vtex.mocked-analytics` on **step 04**.

#### What problem is this solving?

The documentation was unclear regarding the possibility that you would still need to install mocked-analytics even if you were running the app on the appliancetheme account.

#### Types of changes

- [x] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
