### PR TITLE
Fix broken links Calling Commerce APIs course

### DIFF
--- a/courses/calling-commerce-apis/steps/02_references/en.md
+++ b/courses/calling-commerce-apis/steps/02_references/en.md
@@ -6,7 +6,7 @@ In this step, you will learn how to find the documentation for VTEX APIs, as wel
 
 ## Developer Portal
 
-Before starting to develop your integration with VTEX Commerce APIs, it is essential that you can **discover them** and understand how they work. The VTEX's [Developer Portal](https://developers.vtex.com/reference/get-to-know-vtex-apis) lists all available APIs, as well as explaining how to use each of the endpoints offered.
+Before starting to develop your integration with VTEX Commerce APIs, it is essential that you can **discover them** and understand how they work. The VTEX's [Developer Portal](https://developers.vtex.com/docs/guides/getting-started-list-of-rest-apis) lists all available APIs, as well as explaining how to use each of the endpoints offered.
 
 ![Developers Portal](https://user-images.githubusercontent.com/18706156/92934603-0f3be080-f41e-11ea-95f7-34f0238a8d96.png)
 

--- a/courses/calling-commerce-apis/steps/02_references/pt.md
+++ b/courses/calling-commerce-apis/steps/02_references/pt.md
@@ -6,7 +6,7 @@ Neste passo, você aprenderá como encontrar a documentação das APIs da VTEX, 
 
 ## Portal do Desenvolvedor
 
-Antes de começar a desenvolver sua integração com as APIs de Commerce da VTEX, é fundamental que você possa **descobrí-las** e entender seu funcionamento. O [Portal de Desenvolvedor](https://developers.vtex.com/reference/get-to-know-vtex-apis) da VTEX lista todas as APIs disponíveis, além de conter explicações sobre como usar cada um dos _endpoints_ oferecidos.
+Antes de começar a desenvolver sua integração com as APIs de Commerce da VTEX, é fundamental que você possa **descobrí-las** e entender seu funcionamento. O [Portal de Desenvolvedor](https://developers.vtex.com/docs/guides/getting-started-list-of-rest-apis) da VTEX lista todas as APIs disponíveis, além de conter explicações sobre como usar cada um dos _endpoints_ oferecidos.
 
 ![Portal de Desenvolvedor da VTEX](https://user-images.githubusercontent.com/18706156/92934603-0f3be080-f41e-11ea-95f7-34f0238a8d96.png)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix Learn VTEX broken links - Calling Commerce APIs course

#### What problem is this solving?

Keep documentation updated.

#### Types of changes

- [X] Content fix
- [ ] Answer sheet fix
- [ ] Course refactor
- [ ] New course :rocket:
- [ ] Script bug fix
- [ ] Script feature
