### PR TITLE
Correcting grammar at THREE_SECONDS_MS

### DIFF
--- a/courses/service-course/steps/03_events/answersheet/index.ts
+++ b/courses/service-course/steps/03_events/answersheet/index.ts
@@ -16,7 +16,7 @@ import { updateLiveUsers } from './events/liveUsersUpdate'
 const memoryCache = new LRUCache<string, any>({ max: 5000 })
 metrics.trackCache('status', memoryCache)
 
-const TREE_SECONDS_MS = 3 * 1000
+const THREE_SECONDS_MS = 3 * 1000
 const CONCURRENCY = 10
 
 declare global {
@@ -40,7 +40,7 @@ export default new Service<Clients, State, ParamsContext>({
         exponentialBackoffCoefficient: 2,
         initialBackoffDelay: 50,
         retries: 1,
-        timeout: TREE_SECONDS_MS,
+        timeout: THREE_SECONDS_MS,
         concurrency: CONCURRENCY,
       },
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Rename the timeout constant from `TREE_SECONDS_MS` to `THREE_SECONDS_MS` for clarity and correctness in English.  
Both the declaration and its usage were previously consistent (but misspelled), so this is a non-functional rename for readability.

#### What problem is this solving?

Improves code readability and naming consistency, reducing the chance of future confusion or mismatched references if other files/constants follow the `THREE_SECONDS_MS` pattern (as the current course at `https://learn.vtex.com/docs/course-service-course-step03events-lang-en` does).  

#### Types of changes

- [x] Content fix  
- [ ] Answer sheet fix  
- [ ] Course refactor  
- [ ] New course :rocket:  
- [ ] Script bug fix  
- [ ] Script feature  
